### PR TITLE
test002A: Simplify, parameterise, and prepare 

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -44,7 +44,7 @@ documentation:
     this `SCLK` output running constantly, relying on `/CS`.
 
     NOTE: Besides the main design, I've got simple loopback tests:
-    
+
     *   `TestA[5:0]` feeds a 6-input logical `AND` which outputs to `TestA_out`
     *   `TestB` feeds directly to `TestB_out`
 
@@ -74,7 +74,7 @@ documentation:
         `red`, `green`, and `blue`, each via a 330&ohm; resistor, to their respective VGA colour
         channel input pins.
     *   For a much better display, use at least an RGB222 (upper 2 bits per channel) or RGB333 DAC
-        (all 3 bits per channel), and preferably one that buffers each input.
+        (all 3 bits per channel), and preferably one that buffers each of those digital outputs.
 
   inputs:
     - 'In: MISO'

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -65,10 +65,10 @@ module vga_spi_rom(
                   hpos;
 
   // This is screen-time when we'd normally be storing from MISO to buffer:
-  wire store_data_region = (hpos > STORED_MODE_HEAD+PREAMBLE_LEN && hpos <= STORED_MODE_TAIL);
+  wire store_data_region = (hpos1 >= STORED_MODE_HEAD+PREAMBLE_LEN && hpos1 < STORED_MODE_TAIL);
   // Screen-time when we'd normally display data (directly from MISO, or buffer):
-  wire paint_data_region = (hpos > PREAMBLE_LEN+1 && hpos <= STREAM_LEN+1);
-  //NOTE: +1 because we want to shift data_buffer only AFTER its MSB has been shown.
+  wire paint_data_region = (hpos1 > PREAMBLE_LEN && hpos1 <= STREAM_LEN);
+  //NOTE: 'Greater than' (+1 shift) comparison we want to shift data_buffer only AFTER its MSB has been shown.
 
   //NOTE: posedge of SPI_SCLK, because this is where MISO remains stable...
   always @(posedge spi_sclk) begin

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -6,7 +6,7 @@
 // If MASK_REDUNDANT is defined, a bunch of states that are not explicitly needed are masked out.
 //NOTE: My observation has been that *including* these states may actually lead to simpler
 // logic, I suppose because the internal comparators can be simpler.
-`define MASK_REDUNDANT
+// `define MASK_REDUNDANT
 
 
 module vga_spi_rom(

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -6,7 +6,7 @@
 // If MASK_REDUNDANT is defined, a bunch of states that are not explicitly needed are masked out.
 //NOTE: My observation has been that *including* these states may actually lead to simpler
 // logic, I suppose because the internal comparators can be simpler.
-// `define MASK_REDUNDANT
+`define MASK_REDUNDANT
 
 
 module vga_spi_rom(
@@ -142,15 +142,17 @@ module vga_spi_rom(
       25:   begin spi_mosi <= vpos[5];          end // ADDR[06] <= vpos[5]
       26:   begin spi_mosi <= vpos[4];          end // ADDR[05] <= vpos[4]
       27:   begin spi_mosi <= vpos[3];          end // ADDR[04] <= vpos[3] // Lines are x8 in height since we discard vpos[2:0]
-    `ifndef MASK_REDUNDANT
       28:   begin spi_mosi <= 0;                end // ADDR[03] // This and the below bits cover 0..15 bytes per line (actually 15 total by design).
+    `ifndef MASK_REDUNDANT
       29:   begin spi_mosi <= 0;                end // ADDR[02]
       30:   begin spi_mosi <= 0;                end // ADDR[01]
       31:   begin spi_mosi <= 0;                end // ADDR[00]
+    `endif
     // First DATA output bit from SPI flash ROM arrives at the NEXT RISING edge of clk (i.e. the FALLING edge of spi_sclk) after 31.
     // Turn chip off after reading 128 bits (16 bytes):
       STREAM_LEN:
             begin                 spi_cs <= 0;  end // Chip OFF.
+    `ifndef MASK_REDUNDANT
     // Don't care about MOSI for all other states, but 0 is as fine as any:
       default: begin spi_mosi <= 0; end //SMELL: Assign 'x' instead?
     `endif

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -140,9 +140,10 @@ module vga_spi_rom(
   wire blanking = ~visible;
 
   // On screen, we highlight where byte boundaries would be, by alternating the
-  // background colour every 8 horizontal pixels. Hence, 'odd bytes' are those
-  // where hpos[3] is set, and 'even' are when hpos[3] is clear.
-  wire odd_byte = ~hpos[3]; // Inverted, because on-screen we skip the first 8 pixels.
+  // background colour every 8 horizontal pixels. Our first actual SPI byte
+  // starts at hpos 8, because that's where we've decided to start DIRECT_MODE_HEAD.
+  // Hence, 'even bytes' are those where hpos[3]==1; 'odd' when hpos[3]==0.
+  wire even_byte = hpos[3];
 
   // Data comes from...
   wire data =
@@ -153,7 +154,7 @@ module vga_spi_rom(
     // Force green pixels during MOSI high:
     spi_mosi  ? 9'b000_111_000:
     // Else, B=/CS, G=data, R=odd/even byte.
-                { {3{spi_cs}}, {3{data}}, {3{odd_byte}} };
+                { {3{spi_cs}}, {3{data}}, {3{even_byte}} };
 
   // Dividing lines are blacked out, i.e. first line of each address line pair,
   // because they contain buffer junk, but also to make it easier to see pairs:

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -65,9 +65,9 @@ module vga_spi_rom(
                   hpos;
 
   // This is screen-time when we'd normally be storing from MISO to buffer:
-  wire store_data_region = (hpos >= STORED_MODE_HEAD+PREAMBLE_LEN && hpos < STORED_MODE_TAIL);
+  wire store_data_region = (hpos > STORED_MODE_HEAD+PREAMBLE_LEN && hpos <= STORED_MODE_TAIL);
   // Screen-time when we'd normally display data (directly from MISO, or buffer):
-  wire paint_data_region = (hpos >= PREAMBLE_LEN+1 && hpos <= STREAM_LEN+1);
+  wire paint_data_region = (hpos > PREAMBLE_LEN+1 && hpos <= STREAM_LEN+1);
   //NOTE: +1 because we want to shift data_buffer only AFTER its MSB has been shown.
 
   //NOTE: posedge of SPI_SCLK, because this is where MISO remains stable...

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -3,11 +3,6 @@
 
 `include "helpers.v"
 
-// If MASK_REDUNDANT is defined, a bunch of states that are not explicitly needed are masked out.
-//NOTE: My observation has been that *including* these states may actually lead to simpler
-// logic, I suppose because the internal comparators can be simpler.
-`define MASK_REDUNDANT
-
 
 module vga_spi_rom(
   input               clk,
@@ -23,10 +18,15 @@ module vga_spi_rom(
   input  wire         spi_miso
 );
 
-  localparam        BUFFER_DEPTH = 128;
-  localparam        PREAMBLE_LEN = 32; // 8 command bits, 24 address bits.
-  localparam        STREAM_LEN = PREAMBLE_LEN+BUFFER_DEPTH; // Number of bits in our full SPI read stream.
-  localparam [9:0]  STORED_MODE_START = 448; //(640-PREAMBLE_LEN);
+  localparam        BUFFER_DEPTH      = 128;
+  localparam        SPI_CMD_LEN       = 8;
+  localparam        SPI_ADDR_LEN      = 24;
+  localparam        PREAMBLE_LEN      = SPI_CMD_LEN + SPI_ADDR_LEN;
+  localparam        STREAM_LEN        = PREAMBLE_LEN + BUFFER_DEPTH; // Number of bits in our full SPI read stream.
+  localparam [9:0]  STORED_MODE_HEAD  = 408; //(640-PREAMBLE_LEN); // Run the preamble (32bits, i.e. CMD[7:0] and ADDR[23:0]) to complete at end of 640w line.
+  localparam [9:0]  STORED_MODE_TAIL  = STORED_MODE_HEAD + STREAM_LEN;
+  localparam [9:0]  DIRECT_MODE_HEAD  = 8;
+  localparam [9:0]  DIRECT_MODE_TAIL  = DIRECT_MODE_HEAD + STREAM_LEN;
 
   // --- VGA sync driver: ---
   wire hsync, vsync;
@@ -47,44 +47,39 @@ module vga_spi_rom(
   // vga_sync gives active-high H/VSYNC, but VGA needs active-low, so invert:
   assign {hsync_n,vsync_n} = ~{hsync,vsync};
 
-  // // Inverted clk directly drives SPI SCLK at full speed, continuously:
+  // Inverted clk directly drives SPI SCLK at full speed, continuously:
   assign spi_sclk = ~clk; 
-  // assign spi_sclk = 1'b0;
 
-  // wire stored_mode = vpos[2]==0;  // 
-
-  // This predicts what vpos will be on the next clock cycle. We do this, so
-  // we can determine stored_mode_next, i.e. whether we are commencing a stored
-  // mode line, or a direct-to-screen line.
-  wire [9:0] vpos_next =
-    (!hmax) ? vpos:
-    (!vmax) ? vpos+1'b1:
-              10'd0;
-  wire stored_mode_next = vpos_next[2]==0;
+  // Stored mode or direct mode?
+  wire stored_mode = vpos[2]==0;
   // Even 4-line group: stored mode: read MISO to internal memory; deferred display.
   // Odd  4-line group: direct mode: read and display MISO data directly.
 
-  // This is the 'memory' that stores data read from SPI flash ROM,
-  // when we're in stored_mode:
+  // The 'memory' storing data read from SPI flash ROM, when in stored_mode:
   reg [BUFFER_DEPTH-1:0] data_buffer;
 
   // SPI states follow hpos, with an offset based on stored_mode...
   //NOTE: +1 makes our case() easier to follow with register lag considered.
   wire [9:0] state = 
-    stored_mode_next  ? (hpos + 1'b1 - STORED_MODE_START):
-                        (hpos + 1'b1);
+    stored_mode ? (hpos + 1'b1 - STORED_MODE_HEAD):
+                  (hpos + 1'b1 - DIRECT_MODE_HEAD);
+
+  // This is screen-time when we'd normally be storing from MISO to buffer:
+  wire store_data_region = (hpos >= STORED_MODE_HEAD+PREAMBLE_LEN && hpos < STORED_MODE_TAIL);
+  // Screen-time when we'd normally display data (directly from MISO, or buffer):
+  wire paint_data_region = (hpos >= DIRECT_MODE_HEAD+PREAMBLE_LEN+1 && hpos <= DIRECT_MODE_TAIL+1);
+  //NOTE: +1 because we want to shift data_buffer only AFTER its MSB has been shown.
 
   //NOTE: posedge of SPI_SCLK, because this is where MISO remains stable...
   always @(posedge spi_sclk) begin
-    if (stored_mode_next) begin
-      if (hpos > PREAMBLE_LEN && hpos <= STREAM_LEN) begin
-        // We're in the screen region where buffer needs to be displayed,
-        // so shift out the bits:
-        data_buffer <= {data_buffer[BUFFER_DEPTH-2:0], 1'b0};
-      end else if (state > PREAMBLE_LEN && state <= STREAM_LEN) begin
-        // We're in the region where bits are streaming out via MISO,
-        // so shift them in:
+    if (stored_mode) begin
+      if (store_data_region) begin
+        // Bits are streaming out via MISO, so shift them into data_buffer:
         data_buffer <= {data_buffer[BUFFER_DEPTH-2:0], spi_miso};
+      end else if (paint_data_region) begin
+        // In stored_mode, but this is the typical display region where we want
+        // to SHOW data (in this case from data_buffer): Shift out the bits:
+        data_buffer <= {data_buffer[BUFFER_DEPTH-2:0], 1'b0};
       end
     end
   end
@@ -92,36 +87,22 @@ module vga_spi_rom(
   always @(posedge clk) begin
     // This case() controls SPI signals based on 'state' derived from horizontal
     // pixel position (hpos), with a varying offset...
-    //
-    // In stored_mode, we react at state==0 (which is when hpos==607)
-    // by asserting /CS... just as hpos BECOMES 608 (i.e. 640-32).
-    //
-    // In direct mode, we instead react to state==800 (which is when hpos==799),
-    // because it wraps around from 799 to 0, meaning the next state after 800
-    // is 1 (skipping 0). Hence, state 800 is equivalent to state 0.
 
-    //NOTE: MOSI signals we assert here take effect on FALLING clk edge, because
-    // it is inverted to becoming the rising SCLK of the SPI memory.
+    // MOSI signals asserted here are sampled by SPI chip on FALLING clk edge,
+    // because it's inverted to become the rising SCLK of the SPI memory.
 
     case (state)
     // Turn chip ON, and commence command 03h (READ)...
-      // stored_mode:0 and direct:800 represent the same state for CMD[7]:
-      0:    if (stored_mode_next)  begin spi_mosi <= 0;  spi_cs <= 1;  end // CMD[7], chip ON.
-      800:  if (!stored_mode_next) begin spi_mosi <= 0;  spi_cs <= 1;  end // CMD[7], chip ON.
-    `ifndef MASK_REDUNDANT
+      0:    begin spi_mosi <= 0;  spi_cs <= 1;  end // CMD[7], chip ON.
       1:    begin spi_mosi <= 0;                end // CMD[6].
       2:    begin spi_mosi <= 0;                end // CMD[5].
       3:    begin spi_mosi <= 0;                end // CMD[4].
       4:    begin spi_mosi <= 0;                end // CMD[3].
       5:    begin spi_mosi <= 0;                end // CMD[2].
-    `endif
       6:    begin spi_mosi <= 1;                end // CMD[1].
-    `ifndef MASK_REDUNDANT
       7:    begin spi_mosi <= 1;                end // CMD[0].
-    `endif
     // Address 000000h:
       8:    begin spi_mosi <= 0;                end // ADDR[23]
-    `ifndef MASK_REDUNDANT
       9:    begin spi_mosi <= 0;                end // ADDR[22]
       10:   begin spi_mosi <= 0;                end // ADDR[21]
       11:   begin spi_mosi <= 0;                end // ADDR[20]
@@ -134,7 +115,6 @@ module vga_spi_rom(
       18:   begin spi_mosi <= 0;                end // ADDR[13]
       19:   begin spi_mosi <= 0;                end // ADDR[12]
       20:   begin spi_mosi <= 0;                end // ADDR[11]
-    `endif
       21:   begin spi_mosi <= vpos[9];          end // ADDR[10] <= vpos[9]
       22:   begin spi_mosi <= vpos[8];          end // ADDR[09] <= vpos[8]
       23:   begin spi_mosi <= vpos[7];          end // ADDR[08] <= vpos[7]
@@ -143,82 +123,41 @@ module vga_spi_rom(
       26:   begin spi_mosi <= vpos[4];          end // ADDR[05] <= vpos[4]
       27:   begin spi_mosi <= vpos[3];          end // ADDR[04] <= vpos[3] // Lines are x8 in height since we discard vpos[2:0]
       28:   begin spi_mosi <= 0;                end // ADDR[03] // This and the below bits cover 0..15 bytes per line (actually 15 total by design).
-    `ifndef MASK_REDUNDANT
       29:   begin spi_mosi <= 0;                end // ADDR[02]
       30:   begin spi_mosi <= 0;                end // ADDR[01]
       31:   begin spi_mosi <= 0;                end // ADDR[00]
-    `endif
     // First DATA output bit from SPI flash ROM arrives at the NEXT RISING edge of clk (i.e. the FALLING edge of spi_sclk) after 31.
+    // 32..159 is then each of 128 bits being read from SPI memory.
     // Turn chip off after reading 128 bits (16 bytes):
       STREAM_LEN:
             begin                 spi_cs <= 0;  end // Chip OFF.
-    `ifndef MASK_REDUNDANT
-    // Don't care about MOSI for all other states, but 0 is as fine as any:
-      default: begin spi_mosi <= 0; end //SMELL: Assign 'x' instead?
-    `endif
+    // MOSI<=0 for all other states so it can't litter display with anything else:
+      default:
+            begin spi_mosi <= 0;                end
     endcase
   end
 
   wire blanking = ~visible;
 
-  // Colour guide:
-  // -  Alternate on odd/even 'bytes'.
-  // -  Alternate on stored/direct lines.
-  // -  For RGB111 use each channel's LSB: 'Subtle' in RGB333 is bold in RGB111.
-  //    - This gives us 8 colours (inc. black/white) to work with.
-  // -  MOSI should be its own colour... always?
-  // -  Do we need to see /CS? Probably *can't* see SCLK.
-
   // On screen, we highlight where byte boundaries would be, by alternating the
-  // background colour every 8 horizontal pixels. Hence, 'even bytes' are those
-  // where hpos[3] is clear, and 'odd' are when hpos[3] is set.
-  wire even_byte = hpos[3];
+  // background colour every 8 horizontal pixels. Hence, 'odd bytes' are those
+  // where hpos[3] is set, and 'even' are when hpos[3] is clear.
+  wire odd_byte = ~hpos[3]; // Inverted, because on-screen we skip the first 8 pixels.
 
   // Data comes from...
-  wire data = (hpos >= PREAMBLE_LEN) &
-    (stored_mode_next  ? data_buffer[BUFFER_DEPTH-1]:  // ...memory, in stored mode.
-                        spi_miso);                     // ...chip, in direct mode.
+  wire data =
+    stored_mode ? data_buffer[BUFFER_DEPTH-1]:  // ...memory, in stored mode.
+                  spi_miso;                     // ...chip, in direct mode.
 
   wire `RGB pixel_color =
+    // Force green pixels during MOSI high:
     spi_mosi  ? 9'b000_111_000:
-                { {3{spi_cs}}, {3{data}}, {3{even_byte}} };
-    // { {3{~stored_mode}}, {3{data}}, {3{~even_byte}} };
+    // Else, B=/CS, G=data, R=odd/even byte.
+                { {3{spi_cs}}, {3{data}}, {3{odd_byte}} };
 
+  // Dividing lines are blacked out, i.e. first line of each address line pair,
+  // because they contain buffer junk, but also to make it easier to see pairs:
   wire dividing_line = vpos[2:0]==0;
-
-  
-  // wire `RGB rom_data_color = 
-  //   {3'b000, {3{spi_mosi}}, 3'b000} | ( // Show MOSI in the green channel.
-  // // Blue byte boundary: White if MISO==1, blue if 0.
-  //   (byte_alt==0)   ?(
-  //                     (spi_miso==0)?
-  //                     { 3'b011,         3'b000,         3'b000  }:  // Dark blue
-  //                     { 3'b111,         3'b100,         3'b010  }   // Sky blue
-  //                   ):
-  // // Red byte boundary: Yellow if MISO==1, dark red if 0.
-  //   (spi_miso==0)   ? { 3'b000,         3'b000,         3'b011  }:  // Dark red
-  //                     { 3'b000,         3'b100,         3'b111  }   // Strong yellow
-  // );
-
-  // wire ram_bit = (vpos[1:0]==0) ? 1'b0 : data_buffer[BUFFER_DEPTH-1];
-  // wire `RGB ram_data_color = 
-  //   {3'b000, {3{spi_mosi}}, 3'b000} | ( // Show MOSI in the green channel.
-  // // Green byte boundary:
-  //   (byte_alt==0)   ?(
-  //                     (ram_bit==0)?
-  //                     { 3'b000,         3'b010,         3'b000  }:  // Dark green
-  //                     { 3'b011,         3'b101,         3'b001  }   // Bright green
-  //                   ):
-  // // Magenta byte boundary:
-  //   (ram_bit==0)    ? { 3'b011,         3'b000,         3'b010  }:  // Dark purple
-  //                     { 3'b111,         3'b000,         3'b111  }   // Bright magenta
-  // );
-
-  // // Even lines are black, so it's easier to see individual bytes:
-  // wire `RGB pixel_color =
-  //   source_direct ? rom_data_color:
-  //                   ram_data_color;
-  //                   //(vpos[1:0] == 0) ? 9'd0 : ram_data_color;
 
   assign rgb =
     (blanking)      ? 9'b000_000_000: // Black for blanking.

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -6,7 +6,7 @@
 // If MASK_REDUNDANT is defined, a bunch of states that are not explicitly needed are masked out.
 //NOTE: My observation has been that *including* these states may actually lead to simpler
 // logic, I suppose because the internal comparators can be simpler.
-// `define MASK_REDUNDANT
+`define MASK_REDUNDANT
 
 
 module vga_spi_rom(


### PR DESCRIPTION
Rolls up test001-case400, test002-case0, and test002A.
* Drops back to RGB111 for now, but in a way we can build on with forwards/backwards compatibility.
* Shows `/CS` on-screen.
* Introduces some parameters that make the code neater and more readable.
* Makes some comparisons/calculations way more sensible, and in some cases may correct other glitches.
* Brings full 'stored mode' region into the visible display area.
* Aligns things correctly (byte boundaries).
