### PR TITLE
test005: FSM out, combo logic in. Treat data_buffer as RAM

### DIFF
--- a/src/config.tcl
+++ b/src/config.tcl
@@ -12,7 +12,7 @@
 
 # PL_TARGET_DENSITY - You can increase this if Global Placement fails with error GPL-0302.
 # Users have reported that values up to 0.8 worked well for them.
-set ::env(PL_TARGET_DENSITY) 0.6
+set ::env(PL_TARGET_DENSITY) 0.8
 
 # CLOCK_PERIOD - Increase this in case you are getting setup time violations.
 # The value is in nanoseconds, so 20ns == 50MHz.

--- a/src/config.tcl
+++ b/src/config.tcl
@@ -12,7 +12,7 @@
 
 # PL_TARGET_DENSITY - You can increase this if Global Placement fails with error GPL-0302.
 # Users have reported that values up to 0.8 worked well for them.
-set ::env(PL_TARGET_DENSITY) 0.8
+set ::env(PL_TARGET_DENSITY) 0.9
 
 # CLOCK_PERIOD - Increase this in case you are getting setup time violations.
 # The value is in nanoseconds, so 20ns == 50MHz.

--- a/src/config.tcl
+++ b/src/config.tcl
@@ -12,7 +12,7 @@
 
 # PL_TARGET_DENSITY - You can increase this if Global Placement fails with error GPL-0302.
 # Users have reported that values up to 0.8 worked well for them.
-set ::env(PL_TARGET_DENSITY) 0.9
+set ::env(PL_TARGET_DENSITY) 0.6
 
 # CLOCK_PERIOD - Increase this in case you are getting setup time violations.
 # The value is in nanoseconds, so 20ns == 50MHz.

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -18,7 +18,8 @@ module vga_spi_rom(
   input  wire         spi_miso
 );
 
-  localparam [9:0]    BUFFER_DEPTH      = 192;                            // Number of SPI data bits to read per line. Also sets size of our storage memory.
+  localparam [9:0]    BUFFER_DEPTH      = 136;                            // Number of SPI data bits to read per line. Also sets size of our storage memory.
+  localparam          BUFFER_ADDR_TOP   = $clog2(BUFFER_DEPTH)-1;         // Buffer's address MSB, i.e. index into buffer.
   localparam [9:0]    SPI_CMD_LEN       = 8;                              // Number of bits to send first as SPI command.
   localparam [9:0]    SPI_ADDR_LEN      = 24;                             // Number of address bits to send after SPI command.
   localparam [9:0]    PREAMBLE_LEN      = SPI_CMD_LEN + SPI_ADDR_LEN;     // Total length of CMD+ADDR bits, before chip will start producing output data.
@@ -137,7 +138,7 @@ module vga_spi_rom(
   // Work out the bit index in the data_buffer shift reg for retrieval of
   // each pixel, as relative to hpos and where we want those bits on screen:
   wire [9:0] data_index_base = BUFFER_DEPTH+PREAMBLE_LEN-10'd1 - hpos;
-  wire [7:0] data_index = data_index_base[7:0]; // Needs to be enough bits to cover BUFFER_DEPTH.
+  wire [BUFFER_ADDR_TOP:0] data_index = data_index_base[BUFFER_ADDR_TOP:0]; // Enough bits to cover BUFFER_DEPTH.
   // Data comes from...
   wire mask_stored = stored_mode && (hpos < PREAMBLE_LEN || hpos >= STREAM_LEN); //TODO: Make optional.
   wire data =

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -12,19 +12,19 @@ module vga_spi_rom(
   output wire         vsync_n,
   output wire `RGB    rgb,
   // SPI ROM interface:
-  output wire         spi_cs,   //NOTE: This is active HIGH.
+  output wire         spi_cs, //NOTE: Active HIGH. Most chips use active LOW (csb, cs_n, ss_n, whatever). Invert as needed in parent module.
   output wire         spi_sclk,
   output wire         spi_mosi,
   input  wire         spi_miso
 );
 
-  localparam [9:0]    BUFFER_DEPTH      = 128;
-  localparam [9:0]    SPI_CMD_LEN       = 8;
-  localparam [9:0]    SPI_ADDR_LEN      = 24;
-  localparam [9:0]    PREAMBLE_LEN      = SPI_CMD_LEN + SPI_ADDR_LEN;
-  localparam [9:0]    STREAM_LEN        = PREAMBLE_LEN + BUFFER_DEPTH; // Number of bits in our full SPI read stream.
-  localparam [9:0]    STORED_MODE_HEAD  = 416; // (640-PREAMBLE_LEN) would run preamble (32bits, CMD[7:0] + ADDR[23:0]) to complete at end of 640w line.
-  localparam [9:0]    STORED_MODE_TAIL  = STORED_MODE_HEAD + STREAM_LEN;
+  localparam [9:0]    BUFFER_DEPTH      = 128;                            // Number of SPI data bits to read per line. Also sets size of our storage memory.
+  localparam [9:0]    SPI_CMD_LEN       = 8;                              // Number of bits to send first as SPI command.
+  localparam [9:0]    SPI_ADDR_LEN      = 24;                             // Number of address bits to send after SPI command.
+  localparam [9:0]    PREAMBLE_LEN      = SPI_CMD_LEN + SPI_ADDR_LEN;     // Total length of CMD+ADDR bits, before chip will start producing output data.
+  localparam [9:0]    STREAM_LEN        = PREAMBLE_LEN + BUFFER_DEPTH;    // Number of bits in our full SPI read stream.
+  localparam [9:0]    STORED_MODE_HEAD  = 416;                            // When, in VGA line, to start the 'stored mode' sequence. (640-PREAMBLE_LEN) would run preamble (32bits, CMD[7:0] + ADDR[23:0]) to complete at end of 640w line.
+  localparam [9:0]    STORED_MODE_TAIL  = STORED_MODE_HEAD + STREAM_LEN;  // When, in VGA line, to STOP the 'stored mode' sequence, to prevent buffer overrun.
 
   // --- VGA sync driver: ---
   wire hsync, vsync;
@@ -47,6 +47,9 @@ module vga_spi_rom(
 
   // Inverted clk directly drives SPI SCLK at full speed, continuously:
   assign spi_sclk = ~clk; 
+  // Why inverted? Because this allows us to set up MOSI on rising clk edge,
+  // then it's stable by the spi_sclk would subsequently rise to clock that MOSI
+  // data into the SPI chip.
 
   // Stored mode or direct mode?
   wire stored_mode = vpos[2]==0;
@@ -57,18 +60,19 @@ module vga_spi_rom(
   reg [BUFFER_DEPTH-1:0] data_buffer;
 
   // SPI states follow hpos, with an offset based on stored_mode...
-  //NOTE: +1 makes our case() easier to follow with register lag considered.
   wire [9:0] state = 
     stored_mode ? (hpos - STORED_MODE_HEAD):
                   hpos;
 
-  // This is screen-time when we'd normally be storing from MISO to buffer:
+  // This screen-time range is when we store from MISO to buffer:
   wire store_data_region = (hpos >= STORED_MODE_HEAD+PREAMBLE_LEN && hpos < STORED_MODE_TAIL);
-  // Screen-time when we'd normally display data (directly from MISO, or buffer):
-  wire paint_data_region = (hpos > PREAMBLE_LEN && hpos <= STREAM_LEN);
-  //NOTE: 'Greater than' (+1 shift) comparison we want to shift data_buffer only AFTER its MSB has been shown.
+  //NOTE: Could/should we instead use 'state'?
 
-  //NOTE: posedge of SPI_SCLK, because this is where MISO remains stable...
+  // This screen-time range is when we display data (MISO direct, or from buffer):
+  wire paint_data_region = (hpos > PREAMBLE_LEN && hpos <= STREAM_LEN);
+  //NOTE: '>', not '>=' (i.e. +1 shift) as we want to shift data_buffer only AFTER its MSB has been shown.
+
+  //NOTE: BEWARE: posedge of SPI_SCLK (not clk) here, because this is where MISO output is stable...
   always @(posedge spi_sclk) begin
     if (stored_mode) begin
       if (store_data_region) begin
@@ -85,38 +89,58 @@ module vga_spi_rom(
   // Chip is ON for the whole duration of our SPI read stream:
   assign spi_cs = state < STREAM_LEN;
 
-  // MOSI depends on a CMD/ADDR 32-bit sequence.
-  //NOTE: This could be stored in a vector that we shift (or index),
-  // or a case(), or could be a memory array.
-  // assign spi_mosi =
-  //   (state<  6)               ? 1'b0:           // CMD[7:2] is 'b000000.
-  //   (state== 6 || state== 7)  ? 1'b1:           // CMD[1:0] is 'b11.
-  //                             //ADDR[23:11] is 0.
-  //   (state>=21 && state<=27)  ? vpos[30-state]: // ADDR[10:4] is vpos[9:3]
-  //                             //ADDR[3:0] is 0.
-  //   (state>=PREAMBLE_LEN)     ? 1'bx:           // Don't care after preamble.
-  //                               0;              // Other preamble bits must be 0.
-
-  // // An alternative, but this one is messy on the MOSI line which makes our
-  // // display really hard to interpret:
-  // wire [4:0] pstate = state[4:0];
-  // assign spi_mosi =
-  //   (pstate== 6 || pstate== 7)  ? 1:              // CMD[1:0] is 'b11.
-  //   (pstate>=21 && pstate<=27)  ? vpos[30-pstate]: // ADDR[10:4] is vpos[9:3]
-  //                                 0;              // 0 for all other preamble bits
-  //                                                 // and beyond.
-
-  // This alternative seems to be the simplest:
+  // This is a simple way to work out what data to present at MOSI during the
+  // SPI preamble:
   assign spi_mosi =
     (state== 6 || state== 7)  ? 1'b1:           // CMD[1:0] is 'b11.
     (state>=21 && state<=27)  ? vpos[30-state]: // ADDR[10:4] is vpos[9:3]
                                 1'b0;           // 0 for all other preamble bits
                                                 // and beyond.
+  // The above combo logic for spi_cs and spi_mosi gives us the following output
+  // for each 'state':
+  //
+  // | state    | spi_cs   | spi_mosi | note                              |
+  // |---------:|---------:|---------:|:----------------------------------|
+  // | (n)      | 0        | 0        | (any state not otherwise covered) |
+  // |  0       | 1        | 0        | CMD[7]; chip ON                   |
+  // |  1       | 1        | 0        | CMD[6]                            |
+  // |  2       | 1        | 0        | CMD[5]                            |
+  // |  3       | 1        | 0        | CMD[4]                            |
+  // |  4       | 1        | 0        | CMD[3]                            |
+  // |  5       | 1        | 0        | CMD[2]                            |
+  // |  6       | 1        | 1        | CMD[1]                            |
+  // |  7       | 1        | 1        | CMD[0] => CMD 03h (READ) loaded.  |
+  // |  8       | 1        | 0        | ADDR[23]                          |
+  // |  9       | 1        | 0        | ADDR[22]                          |
+  // | 10       | 1        | 0        | ADDR[21]                          |
+  // | 11       | 1        | 0        | ADDR[20]                          |
+  // | 12       | 1        | 0        | ADDR[19]                          |
+  // | 13       | 1        | 0        | ADDR[18]                          |
+  // | 14       | 1        | 0        | ADDR[17]                          |
+  // | 15       | 1        | 0        | ADDR[16]                          |
+  // | 16       | 1        | 0        | ADDR[15]                          |
+  // | 17       | 1        | 0        | ADDR[14]                          |
+  // | 18       | 1        | 0        | ADDR[13]                          |
+  // | 19       | 1        | 0        | ADDR[12]                          |
+  // | 20       | 1        | 0        | ADDR[11]                          |
+  // | 21       | 1        | vpos[9]  | ADDR[10]                          |
+  // | 22       | 1        | vpos[8]  | ADDR[9]                           |
+  // | 23       | 1        | vpos[7]  | ADDR[8]                           |
+  // | 24       | 1        | vpos[6]  | ADDR[7]                           |
+  // | 25       | 1        | vpos[5]  | ADDR[6]                           |
+  // | 26       | 1        | vpos[4]  | ADDR[5]                           |
+  // | 27       | 1        | vpos[3]  | ADDR[4]                           |
+  // | 28       | 1        | 0        | ADDR[3]                           |
+  // | 29       | 1        | 0        | ADDR[2]                           |
+  // | 30       | 1        | 0        | ADDR[1]                           |
+  // | 31       | 1        | 0        | ADDR[0]                           |
+  // | 32..159  | 1        | 0        | MOSI=dummy, MISO=read bit         |
+  // | 160      | 0        | 0        | Chip OFF                          |
 
   // On screen, we highlight where byte boundaries would be, by alternating the
   // background colour every 8 horizontal pixels. 'Even bytes' are those where
-  // hpos[3]==1; 'odd' when hpos[3]==0.
-  wire even_byte = hpos[3];
+  // hpos[3]==0; 'odd' when hpos[3]==1.
+  wire odd_byte = hpos[3];
 
   // Data comes from...
   wire data =
@@ -127,12 +151,13 @@ module vga_spi_rom(
     // Force green pixels during MOSI high:
     spi_mosi  ? 9'b000_111_000:
     // Else, B=/CS, G=data, R=odd/even byte.
-                { {3{spi_cs}}, {3{data}}, {3{~even_byte}} };
+                { {3{spi_cs}}, {3{data}}, {3{~odd_byte}} };
 
   // Dividing lines are blacked out, i.e. first line of each address line pair,
   // because they contain buffer junk, but also to make it easier to see pairs:
   wire dividing_line = vpos[2:0]==0;
 
+  // Decide what the final RGB pixel output colour is:
   assign rgb =
     (!visible)      ? 9'b000_000_000: // Black for blanking.
     (dividing_line) ? 9'b000_000_000: // Black for dividing lines.

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -18,7 +18,7 @@ module vga_spi_rom(
   input  wire         spi_miso
 );
 
-  localparam [9:0]    BUFFER_DEPTH      = 128;                            // Number of SPI data bits to read per line. Also sets size of our storage memory.
+  localparam [9:0]    BUFFER_DEPTH      = 256;                            // Number of SPI data bits to read per line. Also sets size of our storage memory.
   localparam [9:0]    SPI_CMD_LEN       = 8;                              // Number of bits to send first as SPI command.
   localparam [9:0]    SPI_ADDR_LEN      = 24;                             // Number of address bits to send after SPI command.
   localparam [9:0]    PREAMBLE_LEN      = SPI_CMD_LEN + SPI_ADDR_LEN;     // Total length of CMD+ADDR bits, before chip will start producing output data.
@@ -140,7 +140,7 @@ module vga_spi_rom(
 
   // Data comes from...
   wire [9:0] data_index_base = hpos-PREAMBLE_LEN;
-  wire [6:0] data_index = ~data_index_base[6:0];
+  wire [7:0] data_index = ~data_index_base[7:0]; // Needs to be enough bits to cover BUFFER_DEPTH.
   wire data =
     stored_mode ? data_buffer[data_index]:  // ...memory, in stored mode.
                   spi_miso;                 // ...chip, in direct mode.

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -65,7 +65,7 @@ module vga_spi_rom(
                   hpos;
 
   // This screen-time range is when we store from MISO to buffer:
-  wire store_data_region = (hpos >= STORED_MODE_HEAD+PREAMBLE_LEN && hpos < STORED_MODE_TAIL);
+  wire store_data_region = (state >= PREAMBLE_LEN && state < STREAM_LEN);
   //NOTE: Could/should we instead use 'state'?
 
   // This screen-time range is when we display data (MISO direct, or from buffer):

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -90,21 +90,21 @@ module vga_spi_rom(
   // MOSI depends on a CMD/ADDR 32-bit sequence.
   //NOTE: This could be stored in a vector that we shift (or index),
   // or a case(), or could be a memory array.
-  assign spi_mosi =
-    (state<  6)               ? 1'b0:           // CMD[7:2] is 'b000000.
-    (state== 6 || state== 7)  ? 1'b1:           // CMD[1:0] is 'b11.
-                              //ADDR[23:11] is 0.
-    (state>=21 && state<=27)  ? vpos[30-state]: // ADDR[10:4] is vpos[9:3]
-                              //ADDR[3:0] is 0.
-    (state>=PREAMBLE_LEN)     ? 1'bx:           // Don't care after preamble.
-                                0;              // Other preamble bits must be 0.
+  // assign spi_mosi =
+  //   (state<  6)               ? 1'b0:           // CMD[7:2] is 'b000000.
+  //   (state== 6 || state== 7)  ? 1'b1:           // CMD[1:0] is 'b11.
+  //                             //ADDR[23:11] is 0.
+  //   (state>=21 && state<=27)  ? vpos[30-state]: // ADDR[10:4] is vpos[9:3]
+  //                             //ADDR[3:0] is 0.
+  //   (state>=PREAMBLE_LEN)     ? 1'bx:           // Don't care after preamble.
+  //                               0;              // Other preamble bits must be 0.
 
   // An alternative:
-  // assign spi_mosi =
-  //   (state== 6 || state== 7)  ? 1:              // CMD[1:0] is 'b11.
-  //   (state>=21 && state<=27)  ? vpos[30-state]: // ADDR[10:4] is vpos[9:3]
-  //                               0;              // 0 for all other preamble bits
-  //                                               // and beyond.
+  assign spi_mosi =
+    (state== 6 || state== 7)  ? 1:              // CMD[1:0] is 'b11.
+    (state>=21 && state<=27)  ? vpos[30-state]: // ADDR[10:4] is vpos[9:3]
+                                0;              // 0 for all other preamble bits
+                                                // and beyond.
 
   wire blanking = ~visible;
 

--- a/src/vga_spi_rom.v
+++ b/src/vga_spi_rom.v
@@ -99,12 +99,20 @@ module vga_spi_rom(
   //   (state>=PREAMBLE_LEN)     ? 1'bx:           // Don't care after preamble.
   //                               0;              // Other preamble bits must be 0.
 
-  // An alternative:
+  // // An alternative:
+  // assign spi_mosi =
+  //   (state== 6 || state== 7)  ? 1:              // CMD[1:0] is 'b11.
+  //   (state>=21 && state<=27)  ? vpos[30-state]: // ADDR[10:4] is vpos[9:3]
+  //                               0;              // 0 for all other preamble bits
+  //                                               // and beyond.
+
+  // Another alternative:
+  wire [4:0] pstate = state[4:0];
   assign spi_mosi =
-    (state== 6 || state== 7)  ? 1:              // CMD[1:0] is 'b11.
-    (state>=21 && state<=27)  ? vpos[30-state]: // ADDR[10:4] is vpos[9:3]
-                                0;              // 0 for all other preamble bits
-                                                // and beyond.
+    (pstate== 6 || pstate== 7)  ? 1:              // CMD[1:0] is 'b11.
+    (pstate>=21 && pstate<=27)  ? vpos[30-pstate]: // ADDR[10:4] is vpos[9:3]
+                                  0;              // 0 for all other preamble bits
+                                                  // and beyond.
 
   wire blanking = ~visible;
 

--- a/src/vga_sync.v
+++ b/src/vga_sync.v
@@ -55,7 +55,7 @@ module vga_sync #(
   // Vertical tracing:
   always @(posedge clk) begin
           if (reset)                      vpos <= 0;
-    else  if (hmax)                       vpos <= (vmax) ? 0 : vpos + 1'b1;
+    else  if (hmax)                       vpos <= (vmax) ? 1'b0 : vpos + 1'b1;
   end
 
   // HSYNC:


### PR DESCRIPTION
See [0159](https://github.com/algofoogle/journal/blob/master/0159-2023-10-14.md) for more info.

Skip test003 (registered outputs) for now... it might be an option to turn on/off in a future version.

Merge test004: replace FSM with simpler combo logic.

Merge test005: treat data_buffer as RAM, using bit index to read data directly when needed for painting on screen, instead of doing shifting of data_buffer to screen.